### PR TITLE
Make Ctrl+Q exits the editor.

### DIFF
--- a/src/menu.ml
+++ b/src/menu.ml
@@ -96,7 +96,7 @@ let edit ~browser ~group ~flags
   let comment = GMenu.menu_item ~label:"Comment Block" ~packing:menu#add () in
   ignore (comment#connect#activate ~callback:(fun () ->
       editor#with_current_page (fun page -> ignore (page#ocaml_view#toggle_comment ()))));
-  comment#add_accelerator ~group ~modi:[`CONTROL] GdkKeysyms._q ~flags;
+  comment#add_accelerator ~group ~modi:[`CONTROL] GdkKeysyms._slash ~flags;
   (* Change To Uppercase/Lowercase *)
   let toggle_case = GMenu.menu_item ~label:"Convert To Uppercase/Lowercase" ~packing:menu#add () in
   ignore (toggle_case#connect#activate ~callback:(fun () ->

--- a/src/menu_file.ml
+++ b/src/menu_file.ml
@@ -182,6 +182,7 @@ let file ~browser ~group ~flags items =
   let _ = GMenu.separator_item ~packing:menu#add () in
   let quit = GMenu.image_menu_item ~label:"Exit" ~packing:menu#add () in
   ignore (quit#connect#activate ~callback:(fun () -> browser#exit editor ()));
+  quit#add_accelerator ~group ~modi:[`CONTROL] GdkKeysyms._q ~flags;
   (* callback *)
   ignore (file#misc#connect#state_changed ~callback:begin fun _ ->
       let page = editor#get_page `ACTIVE in

--- a/src/otherwidgets/key_assist.ml
+++ b/src/otherwidgets/key_assist.ml
@@ -42,7 +42,7 @@ let markup_right = "\
 let markup_left = "\
 <b><big>Editor</big></b>
 
-<tt><b>Ctrl+Q</b></tt>: Selects the nearest comment block and adds comment or removes comment. If you press <tt>Ctrl+Q</tt> when a space character is selected, you get <tt>(* &lt;cursor&gt; *)</tt>; when two space characters are selected, you get <tt>(** &lt;cursor&gt; *)</tt>.
+<tt><b>Ctrl+/</b></tt>: Selects the nearest comment block and adds comment or removes comment. If you press <tt>Ctrl+/</tt> when a space character is selected, you get <tt>(* &lt;cursor&gt; *)</tt>; when two space characters are selected, you get <tt>(** &lt;cursor&gt; *)</tt>.
 
 <tt><b>Ctrl+W</b></tt>: Selects a word; when pressed repeatedly cycles through the various parts (separated by '_' or '.') of an identifier.
 


### PR DESCRIPTION
Comment/Uncomment functionality has been moved to assigned to Ctrl+/.